### PR TITLE
Change AddRandomClothes() to use the new model

### DIFF
--- a/src/ArenaOverhaul/TeamTournament/TeamTournamentMissionController.cs
+++ b/src/ArenaOverhaul/TeamTournament/TeamTournamentMissionController.cs
@@ -209,10 +209,10 @@ namespace ArenaOverhaul.TeamTournament
 
         private void AddRandomClothes(TeamTournamentMember member)
         {
-            var randomBattleEquipment = member.Character.RandomBattleEquipment;
+            var participantArmor = Campaign.Current.Models.TournamentModel.GetParticipantArmor(member.Character);
             for (int i = 5; i < 10; i++)
             {
-                var equipmentFromSlot = randomBattleEquipment.GetEquipmentFromSlot((EquipmentIndex) i);
+                var equipmentFromSlot = participantArmor.GetEquipmentFromSlot((EquipmentIndex) i);
                 if (equipmentFromSlot.Item != null)
                 {
                     member.MatchEquipment!.AddEquipmentToSlotWithoutAgent((EquipmentIndex) i, equipmentFromSlot);


### PR DESCRIPTION
TW changed the way tournament participant armor is added in BL 1.8.0 to use a model. It is easier to modify now and also makes Arena Overhaul compatible with Balanced Tournament Armor, since a user complained that the participants' armor was not being standardized in team tournaments...